### PR TITLE
[fix] [Avatar] Resolve default avatar assets not loading in CDN context

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -7,4 +7,7 @@ const chatbot = parseChatbot();
 
 injectChatbotInWindow(chatbot);
 
+// Force bundling of DefaultAvatar component (prevents tree-shaking)
+import { DefaultAvatar } from '@/components/avatars/DefaultAvatar';
+
 export default chatbot;


### PR DESCRIPTION


0# Summary

- Fix default avatars failing to load when library used externally via CDN
- Prevent tree-shaking from removing conditional fallback component assets

<br>

0# Changes

0## 1. Tree-Shaking Fix Implementation
  - Force import `DefaultAvatar` component in `web.ts` entry point
  - Ensure avatar assets are always bundled regardless of conditional usage
  - Maintain DRY principles by keeping asset imports only in component